### PR TITLE
Makefile: fix building on x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC := clang
+CC ?= clang
 
 CFLAGS ?= -Wall -Werror $(shell pkg-config --cflags libcrypto) -fPIC -Wno-pointer-to-int-cast -Wno-unused-command-line-argument -Wno-deprecated-declarations -framework CoreFoundation
 LDFLAGS ?= 


### PR DESCRIPTION
on x86_64, have to run CC="xcrun -sdk iphoneos clang" make